### PR TITLE
9 fix improper handling of glog dependency in ceres solver

### DIFF
--- a/deps/FindGlog.cmake.patch
+++ b/deps/FindGlog.cmake.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake/FindGlog.cmake b/cmake/FindGlog.cmake
+index 2ef6914..ee16817 100644
+--- a/cmake/FindGlog.cmake
++++ b/cmake/FindGlog.cmake
+@@ -346,9 +346,11 @@ if (NOT GLOG_FOUND)
+     NOT "${LOWERCASE_GLOG_LIBRARY}" MATCHES ".*glog[^/]*")
+ 
+   # add glog::glog target
+-  add_library(glog::glog INTERFACE IMPORTED)
+-  target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
+-  target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
++  if (NOT TARGET glog::glog)
++    add_library(glog::glog INTERFACE IMPORTED)
++    target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIRS})
++    target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
++  endif()
+ 
+   glog_reset_find_library_prefix()
+ 

--- a/deps/install-deps.sh
+++ b/deps/install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## Modify the following lines to install dependencies for your project.
-echo "Installing dependencies for non-ROS packages"
+echo "Installing dependencies for VINS-Mono..."
 apt update -q
 apt install -y --no-install-recommends git libgoogle-glog-dev \
     libgflags-dev \
@@ -9,10 +9,18 @@ apt install -y --no-install-recommends git libgoogle-glog-dev \
     libeigen3-dev \
     libsuitesparse-dev
 
-mkdir ./deps
+main_dir=$(pwd)
+mkdir -p $main_dir/deps
 git clone --depth 1 --branch 2.2.0 https://ceres-solver.googlesource.com/ceres-solver ./deps/ceres-solver
-cd ./deps/ceres-solver
+cd $main_dir/deps/ceres-solver
+
+# Apply patch to fix glog issue
+git apply $main_dir/FindGlog.cmake.patch
+echo "Applied patch to fix glog issue"
+
+# Proceed to build and install Ceres
 mkdir build && cd build
+echo "Building and installing Ceres..."
 cmake .. && make -j10 && make install
 cd ../../..
-rm -rf ./deps
+rm -rf $main_dir/deps

--- a/pose_graph/CMakeLists.txt
+++ b/pose_graph/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV)
 find_package(camodocal REQUIRED)
-# find_package(Ceres REQUIRED) # TODO Remove because it causes failure due to multiple GLOG. 
+find_package(Ceres REQUIRED)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Eigen3)


### PR DESCRIPTION
- Added patch file to update FindGlog.cmake in ceres-solver repo
- Updated install-deps.sh to apply this patch before compilation